### PR TITLE
handle double backslash at end of quoted string

### DIFF
--- a/syntaxes/tcl.tmlanguage.yaml
+++ b/syntaxes/tcl.tmlanguage.yaml
@@ -2806,12 +2806,14 @@ repository:
         name: string.quoted.tcl
       -
         begin: '\s*+(?<!\\)(")'
-        end: '(?<!\\)(")'
+        end: '(?<!\\)((?:\\{2})*)(")'
         beginCaptures:
           '1':
             name: string.quoted.double.open.tcl
         endCaptures:
           '1':
+            name: constant.character.escape
+          '2':
             name: string.quoted.double.close.tcl
         patterns:
           -


### PR DESCRIPTION
fixes issues like these
```
puts "hello world\\"
puts "\\"
```

behaviour for escaped quote should be preserved as-is.

tested interactively.
