### PR TITLE
fix command substitutions embedded in strings terminated with escaped backslashes

### DIFF
--- a/syntaxes/tcl.tmlanguage.yaml
+++ b/syntaxes/tcl.tmlanguage.yaml
@@ -62,7 +62,7 @@ repository:
     patterns:
       -
         begin: '\s*+(?<!\\)(\[)'
-        end: '(?<!\\)(\])'
+        end: '(?:(?<!\\)|(?<=\\{2}))(\])'
         beginCaptures:
           '1':
             name: meta.brace.square.open.tcl


### PR DESCRIPTION
this line breaks subsequent formatting, after a bit of digging - it's because of the escaped backslash before the closing square bracket

```
set parent_prefix "^[re_escape ${parent_path}\\].*"
puts {hello, world}
```

one possible fix attached (tests okay)